### PR TITLE
Autoloading mit Composer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
+composer.lock
+composer.phar
 nbproject/
+vendor/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# Minesweeper
+
+Minesweeper_Webanwendung
+
+## Installation
+
+Clone das Projekt und öffne der Ordner in eine Terminal.
+
+Falls du [Composer](https://getcomposer.org) noch nicht installiert hast, kannst du dir [hier die composer.phar herunterladen](https://getcomposer.org/download/1.2.4/composer.phar) und im Ordner ablegen. Installiere anschließend die Abhängigkeiten.
+
+```shell
+php composer.phar update
+```
+
+Starte den PHP built-in Server, um sofort loszulegen:
+
+```shell
+php -S localhost:8080
+```
+
+Die Anwendung ist jetzt unter http://localhost:8080 erreichbar.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Minesweeper
 
-Minesweeper_Webanwendung
+Minesweeper Webanwendung
 
 ## Installation
 
-Clone das Projekt und öffne der Ordner in eine Terminal.
+Clone das Projekt und öffne den Ordner in einem Terminal.
 
-Falls du [Composer](https://getcomposer.org) noch nicht installiert hast, kannst du dir [hier die composer.phar herunterladen](https://getcomposer.org/download/1.2.4/composer.phar) und im Ordner ablegen. Installiere anschließend die Abhängigkeiten.
+Falls du [Composer](https://getcomposer.org) noch nicht installiert hast, kannst du dir [hier die composer.phar herunterladen](https://getcomposer.org/download/1.2.4/composer.phar) und im Ordner ablegen. Installiere anschließend die Abhängigkeiten:
 
 ```shell
 php composer.phar update

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,15 @@
+{
+    "name": "Minesweeper",
+    "type": "project",
+    "description": "Minesweeper_Webanwendung",
+    "homepage": "https://github.com/GevaterTod4711/Minesweeper",
+    "keywords": ["game", "Minesweeper"],
+    "require": {
+        "php": "^5.4 || ^7.0"
+    },
+    "autoload": {
+        "classmap": [
+            "lib/"
+        ]
+    }
+}

--- a/index.php
+++ b/index.php
@@ -2,10 +2,8 @@
 
 session_start();
 
-require 'lib/Template.class.php';
+require 'vendor/autoload.php';
 
 $tpl = new Template();
 $tpl->assign('{$title}', 'Register');
 $tpl->display('templates/register.tpl.html');
-
-?>


### PR DESCRIPTION
Dieser PR führt [Composer](https://getcomposer.org), den defacto Standard Dependendy Manager für PHP, für das Autoloading der Klassen ein. Damit ist in Zukunft das `require()`n von bestimmten Klassen nicht mehr nötig. Außerdem ermöglicht Composer auch das Installieren von weiteren Libraries wie eine Template-Engine oder OpenID-Library.

Ich habe außerdem eine `README.md` ergänzt, wo die Installation beschrieben ist und wie man schnell den eingebauten PHP-Server startet, um die Webanwendung ohne Apache/nginx zu testen.