### PR TITLE
require Database.class.php wird nicht benötigt

### DIFF
--- a/register.php
+++ b/register.php
@@ -2,8 +2,6 @@
 
 require 'bootstrap.php';
 
-require 'lib/Database.class.php';
-
 $name = filter_input(INPUT_POST,'user',FILTER_SANITIZE_SPECIAL_CHARS);
 $passwort = filter_input(INPUT_POST, 'pw', FILTER_UNSAFE_RAW);
 


### PR DESCRIPTION
Dank dem Autoloading von Composer wird das einzelne Laden von Klassen nicht mehr benötigt. Solange zu Beginn die `bootstrap.php` geladen wird, kann sofort auf alle anderen Klassen zugegriffen werden.

Das Autoloading ist hier definiert: https://github.com/GevaterTod4711/Minesweeper/blob/master/composer.json#L11