### PR TITLE
Bugfix: Reload Twig cache

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -8,5 +8,5 @@ $loader = new Twig_Loader_Filesystem('templates');
 
 $twig = new Twig_Environment($loader, array(
     'cache' => 'cache'.DIRECTORY_SEPARATOR.'twig',
-    'autoload' => true,
+    'auto_reload' => true,
 ));


### PR DESCRIPTION
Bugfix, damit Twig den Cache immer neu lädt, wenn sie das Template geändert hat.